### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 on:
   release:

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,5 +1,9 @@
 name: Build and Push Docker Image
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/Slingexe/hackmud-chat-client/security/code-scanning/1](https://github.com/Slingexe/hackmud-chat-client/security/code-scanning/1)

To fix the problem, we should explicitly declare the minimal necessary `GITHUB_TOKEN` permissions for this workflow, instead of relying on repository or organization defaults. This is done by adding a `permissions:` block to the workflow (at the top, under `name:` or `on:`) or specifically under the `build-and-push` job. Because there is only one job and it doesn’t need any write permissions to the repository, we can set read‑only scopes.

The best fix with no functional change is to add a root‑level `permissions:` block that grants read access to repository contents and read access to packages (for operations involving GHCR, if any internal use of `GITHUB_TOKEN` occurs). This will apply to all jobs by default and will not interfere with the use of explicit secrets for registry login. Concretely, in `.github/workflows/docker-publish.yaml`, insert:

```yaml
permissions:
  contents: read
  packages: read
```

between the `name:` and `on:` (or just below `name:`). No additional imports or methods are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
